### PR TITLE
Add button to refresh Device ID

### DIFF
--- a/mobility-track-android/app/build.gradle
+++ b/mobility-track-android/app/build.gradle
@@ -22,4 +22,5 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:21.0.3'
+    compile 'org.apache.httpcomponents:httpclient:4.5.1'
 }

--- a/mobility-track-android/app/build.gradle
+++ b/mobility-track-android/app/build.gradle
@@ -22,5 +22,4 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:21.0.3'
-    compile 'org.apache.httpcomponents:httpclient:4.5.1'
 }

--- a/mobility-track-android/app/src/main/java/ogr/scorelab/ucsc/mobility_track/MainActivity.java
+++ b/mobility-track-android/app/src/main/java/ogr/scorelab/ucsc/mobility_track/MainActivity.java
@@ -42,6 +42,10 @@ public class MainActivity extends ActionBarActivity {
         txtMac = (TextView) findViewById(R.id.txtMac);
         txtDeviceId = (TextView) findViewById(R.id.txtDeviceId);
 
+        getDeviceId();
+    }
+
+    private void getDeviceId() {
         try {
             String deviceMAC = getDeviceMAC();
             if (deviceMAC == null) {
@@ -75,13 +79,18 @@ public class MainActivity extends ActionBarActivity {
             return true;
         }
 
+        if(id == R.id.action_refresh_device_id) {
+            getDeviceId();
+            return true;
+        }
+
         return super.onOptionsItemSelected(item);
     }
 
     /* start background service */
     public void start(View v) {
         if (deviceId == null) {
-            Toast.makeText(this, "Device unregistered", Toast.LENGTH_LONG).show();
+            Toast.makeText(this, R.string.device_unregistered, Toast.LENGTH_LONG).show();
             return;
         }
         Intent intent = new Intent(this, LocationUpdates.class);
@@ -135,11 +144,15 @@ public class MainActivity extends ActionBarActivity {
         protected void onPostExecute(String s) {
             super.onPostExecute(s);
             if (s == null || s.isEmpty()) {
-                txtDeviceId.setText("Device unregistered");
+                txtDeviceId.setText(R.string.device_unregistered);
                 return;
             }
             try {
                 JSONArray jsonArray = new JSONArray(s);
+                if(jsonArray.length() == 0) {
+                    txtDeviceId.setText(R.string.device_unregistered);
+                    return;
+                }
                 JSONObject jsonObject = jsonArray.getJSONObject(0);
                 deviceId = jsonObject.getString("_id");
                 txtDeviceId.setText(deviceId);

--- a/mobility-track-android/app/src/main/res/menu/menu_main.xml
+++ b/mobility-track-android/app/src/main/res/menu/menu_main.xml
@@ -1,6 +1,8 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools" tools:context=".MainActivity">
+    <item android:id="@+id/action_refresh_device_id" android:title="@string/refresh_device_id"
+        android:orderInCategory="100" app:showAsAction="never" />
     <item android:id="@+id/action_settings" android:title="@string/action_settings"
         android:orderInCategory="100" app:showAsAction="never" />
 </menu>

--- a/mobility-track-android/app/src/main/res/values/strings.xml
+++ b/mobility-track-android/app/src/main/res/values/strings.xml
@@ -4,5 +4,7 @@
     <string name="app_name">Mobility-Track</string>
     <string name="hello_world">Hello world!</string>
     <string name="action_settings">Settings</string>
+    <string name="device_unregistered">Device unregistered</string>
+    <string name="refresh_device_id">Refresh Device ID</string>
 
 </resources>


### PR DESCRIPTION
The refresh button is useful for updating the device ID from the server. For instance, if the device is not registered and the app is started it will show that the device is unregistered. The user can register the device with the MAC displayed on the app and then click refresh to retrieve the new device ID.

I have also moved the string 'Device unregistered' text to strings.xml (for localization support).